### PR TITLE
more smoke test fixes

### DIFF
--- a/tests/smoke_tests/smoke_tests_utils.py
+++ b/tests/smoke_tests/smoke_tests_utils.py
@@ -765,8 +765,9 @@ def increase_initial_delay_seconds_for_slow_cloud(cloud: str):
 
 
 def is_remote_server_test() -> bool:
-    return os.environ.get('PYTEST_SKYPILOT_REMOTE_SERVER_TEST',
-                          None) is not None
+    return os.environ.get(
+        'PYTEST_SKYPILOT_REMOTE_SERVER_TEST',
+        None) is not None or api_server_endpoint_configured_in_env_file()
 
 
 def pytest_controller_cloud() -> Optional[str]:

--- a/tests/smoke_tests/test_region_and_zone.py
+++ b/tests/smoke_tests/test_region_and_zone.py
@@ -273,7 +273,14 @@ def test_docker_storage_mounts(generic_cloud: str, image_id: str):
     # created in the centralus region when getting the storage account. We
     # should set the cluster to be launched in the same region.
     region_str = f'/centralus' if generic_cloud == 'azure' else ''
-    if azure_mount_unsupported_ubuntu_version in image_id:
+    if smoke_tests_utils.api_server_endpoint_configured_in_env_file():
+        # Assume only AWS is used for storage when using a remote API server.
+        # TODO: Find a better way to decide which cloud to use for storage
+        # when using a remote API server.
+        content = template.render(storage_name=storage_name,
+                                  include_gcs_mount=False,
+                                  include_azure_mount=False)
+    elif azure_mount_unsupported_ubuntu_version in image_id:
         # The store for mount_private_mount is not specified in the template.
         # If we're running on Azure, the private mount will be created on
         # azure blob. Also, if we're running on Kubernetes, the private mount


### PR DESCRIPTION
- some tests were failing because we didn't have `gcp` enabled on the Coreweave API server, meanwhile `include_gcs_mount` is True by default -> We either have to check on the remote API server, which clouds are enabled, or assume that for example only AWS is going to be enabled
- I think `is_remote_server_test()` needs to be modified to also check `api_server_endpoint_configured_in_env_file()`?

Remaining issues:
1. [test_using_file_mounts_with_env_vars](https://buildkite.com/skypilot-1/smoke-tests/builds/2902/steps/table?sid=0198f0f9-f980-45e7-ae31-89dd82c743c7), [test_kubernetes_storage_mounts](https://buildkite.com/skypilot-1/smoke-tests/builds/2902/steps/table?sid=0198f0f9-f980-4124-9630-59653683dab3) is also failing because it requires GCP access
2. `sky logs --sync-down` taking so long (see [slack thread](https://assemble-platforms.slack.com/archives/C07PVLJSXD0/p1756412651386459?thread_ts=1756346988.980369&cid=C07PVLJSXD0)) -> still looking into this
3. HA jobs controller deployment times out, because we're rsync'ing a lot of small files during init and Coreweave's PVCs are backed by NFS: https://assemble-platforms.slack.com/archives/C07PVLJSXD0/p1756419707568979?thread_ts=1756346988.980369&cid=C07PVLJSXD0
4. Weird issue saying the kube context file does not exist
```
__________________________________________________________________ test_jobs_launch_and_logs ___________________________________________________________________
--
  | 2025-08-29 01:02:03 UTC | [gw0] linux -- Python 3.10.18 /home/buildkite/miniconda3/bin/python3
  | 2025-08-29 01:02:03 UTC | tests/smoke_tests/test_basic.py:568: in test_jobs_launch_and_logs
  | 2025-08-29 01:02:03 UTC | job_id, handle = sky.stream_and_get(sky.jobs.launch(task,
  | 2025-08-29 01:02:03 UTC | sky/utils/common_utils.py:616: in _record
  | 2025-08-29 01:02:03 UTC | return f(*args, **kwargs)
  | 2025-08-29 01:02:03 UTC | sky/server/common.py:774: in wrapper
  | 2025-08-29 01:02:03 UTC | return func(*args, **kwargs)
  | 2025-08-29 01:02:03 UTC | sky/utils/annotations.py:27: in wrapper
  | 2025-08-29 01:02:03 UTC | return func(*args, **kwargs)
  | 2025-08-29 01:02:03 UTC | sky/server/rest.py:129: in wrapper
  | 2025-08-29 01:02:03 UTC | return func(*args, **kwargs)
  | 2025-08-29 01:02:03 UTC | sky/client/sdk.py:2071: in stream_and_get
  | 2025-08-29 01:02:03 UTC | return stream_response(request_id,
  | 2025-08-29 01:02:03 UTC | sky/client/sdk.py:154: in stream_response
  | 2025-08-29 01:02:03 UTC | return get(request_id)
  | 2025-08-29 01:02:03 UTC | sky/utils/common_utils.py:616: in _record
  | 2025-08-29 01:02:03 UTC | return f(*args, **kwargs)
  | 2025-08-29 01:02:03 UTC | sky/utils/annotations.py:27: in wrapper
  | 2025-08-29 01:02:03 UTC | return func(*args, **kwargs)
  | 2025-08-29 01:02:03 UTC | sky/client/sdk.py:1979: in get
  | 2025-08-29 01:02:03 UTC | raise error_obj
  | 2025-08-29 01:02:03 UTC | E   ValueError: Failed to load Kubernetes configuration for '(current-context)'. Please check if your kubeconfig file exists at ~/.kube/config and is valid.
  | 2025-08-29 01:02:03 UTC | E   [kubernetes.config.config_exception.ConfigException] Invalid kube-config file. No configuration found.
  | 2025-08-29 01:02:03 UTC | E
  | 2025-08-29 01:02:03 UTC | E   Hint: Kubernetes attempted to query the current-context set in kubeconfig. Check if the current-context is valid.
```


Tested (run the relevant ones):

- [ ] Code formatting: install pre-commit (auto-check on commit) or `bash format.sh`
- [ ] Any manual or new tests for this PR (please specify below)
- [ ] All smoke tests: `/smoke-test` (CI) or `pytest tests/test_smoke.py` (local)
- [ ] Relevant individual tests: `/smoke-test -k test_name` (CI) or `pytest tests/test_smoke.py::test_name` (local)
- [ ] Backward compatibility: `/quicktest-core` (CI) or `pytest tests/smoke_tests/test_backward_compat.py` (local)

<!-- CI commands (/-prefixed) can only be triggered by repo members -->
